### PR TITLE
Migrate CircleCI to Github Actions

### DIFF
--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,0 +1,1 @@
+none yet

--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,1 +1,0 @@
-Something needs to be done about the random test failures.

--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,1 +1,1 @@
-Something needs to be done about the random test failures.
+Something needs to be done about the random test failures. Seriously.

--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,1 +1,1 @@
-Something needs to be done about the random test failures. Seriously.
+Something needs to be done about the random test failures.

--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,1 +1,1 @@
-Something needs to be done about the random test failures
+Something needs to be done about the random test failures.

--- a/.github/instructions.txt
+++ b/.github/instructions.txt
@@ -1,1 +1,1 @@
-none yet
+Something needs to be done about the random test failures

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,12 +1,12 @@
-name: Deploy Main
+name: Test Deployment
 on: 
   push:
-    branches:
+    branches-ignore:
       - master
 jobs:
     deploy-pypi:
         runs-on: ubuntu-latest
-        environment: deployment
+        environment: test-deployment
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v3
@@ -24,16 +24,13 @@ jobs:
               git fetch --prune --unshallow --tags
               sudo python setup.py sdist bdist_wheel
 
-          - name: Push to PyPI
-            run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
-
     deploy-conda:
         runs-on: ubuntu-latest
 # sets default shell to remove need for source to run the conda shell
         defaults:
           run:
             shell: bash -l {0}
-        environment: deployment
+        environment: test-deployment
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v3
@@ -64,10 +61,10 @@ jobs:
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               git fetch --prune --unshallow --tags
-              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)test conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2
+              anaconda upload --force -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}test-*.tar.bz2 --label test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Deploy Main
+on: 
+  push:
+    branches:
+      - master
+jobs:
+    deploy-pypi:
+        runs-on: ubuntu-latest
+        environment: deployment
+        steps:
+          - name: Checkout Repository
+            uses: actions/checkout@v3
+
+          - name: Install Python
+            uses: actions/setup-python@v3
+            with:
+              python-version: '3.7'
+
+          - name: Install Twine
+            run: sudo pip install twine
+
+          - name: Create the distribution
+            run: sudo python setup.py sdist bdist_wheel
+
+          - name: Push to PyPI
+            run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
+
+    deploy-conda:
+        runs-on: ubuntu-latest
+# sets default shell to remove need for source to run the conda shell
+        defaults:
+          run:
+            shell: bash -l {0}
+        environment: deployment
+        steps:
+          - name: Checkout Repository
+            uses: actions/checkout@v3
+
+# Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
+          - name: Install Miniconda
+            uses: conda-incubator/setup-miniconda@v2
+            with:
+              auto-activate-base: true
+              activate-environment: ""
+              miniconda-version: "latest"
+
+          - name: Install the Conda Dependencies
+            run: | 
+              conda config --set always_yes yes --set auto_update_conda false
+              conda update conda
+              conda install conda-build
+
+# run install twice due to client-size to ensure all files downloaded
+# echo yes before login to prevent anaconda bug breaking automation
+# git tags MUST be fetched otherwise output will be blank
+# bash variables cannot be used in github actions, must use actions specific syntax and methods
+          - name: Build the Anaconda Package
+            id: condabuild
+            run: |
+              conda install anaconda-client
+              conda install anaconda-client
+              conda config --set anaconda_upload no
+              echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              git fetch --prune --unshallow --tags
+              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
+
+          - name: Upload the Anaconda Package
+            id: condaload
+            run: |
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
             run: sudo pip install twine
 
           - name: Create the distribution
-            run: sudo python setup.py sdist bdist_wheel
+            run: |
+              git fetch --prune --unshallow --tags
+              sudo python setup.py sdist bdist_wheel
 
           - name: Push to PyPI
             run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,4 @@ jobs:
           - name: Upload the Anaconda Package
             id: condaload
             run: |
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2
+              anaconda upload --force -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,0 +1,29 @@
+name: Test Deployment
+on: 
+  pull_request:
+    branches:
+      - master
+    types: [opened]
+jobs:
+    deploy-pypi-test:
+        runs-on: ubuntu-latest
+        environment: test-deployment
+        steps:
+          - name: Checkout Repository
+            uses: actions/checkout@v3
+
+          - name: Install Python
+            uses: actions/setup-python@v3
+            with:
+              python-version: '3.7'
+
+          - name: Install Twine
+            run: sudo pip install twine
+
+          - name: Create the distribution
+            run: |
+              git fetch --prune --unshallow --tags
+              sudo python setup.py sdist bdist_wheel
+
+          - name: Push to PyPI
+            run: sudo twine upload -r testpypi -u ${{ secrets.PYPI_TEST_USERNAME }} -p ${{ secrets.PYPI_TEST_PASSWORD }} dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,13 +94,11 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              echo "VERSION_FROM_GIT_TAG=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
-              echo "version_from_git_tag=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
+              echo "version_from_git_tag=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4" >> $GITHUB_ENV
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
-              echo "${{ env.VERSION_FROM_GIT_TAG }}"
               echo "${{ env.version_from_git_tag }}"
+              print %ENV
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
               conda install anaconda-client
               conda install anaconda-client
               conda config --set anaconda_upload no
-              yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
+              yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge --numpy 1.16.4
 
           - name: Get the output path and upload the package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
     deploy-conda:
         needs: build
         runs-on: ubuntu-latest
+        defaults:
+          run:
+            shell: bash -l {0}
         environment: deployment
         steps:
           - name: Checkout Repository
@@ -74,14 +77,12 @@ jobs:
 
           - name: Install the Conda Dependencies
             run: | 
-              source /usr/share/miniconda3/etc/profile.d/conda.sh
               conda config --set always_yes yes --set auto_update_conda false
               conda update conda
               conda install conda-build
 
           - name: Build the Anaconda Package
             run: |
-              source /usr/share/miniconda3/etc/profile.d/conda.sh
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
@@ -89,6 +90,5 @@ jobs:
 
           - name: Get the output path and upload the package
             run: |
-              source /usr/share/miniconda3/etc/profile.d/conda.sh
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
 
     deploy-conda:
-        needs: build
+#        needs: build
         runs-on: ubuntu-latest
 # sets default shell to remove need for source to run the conda shell
         defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,13 +94,17 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+#              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
               var=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
               echo "Hmmm $var"
+              echo '::set-output name=gitversion::{git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-}'
+              echo '::set-output name=SELECTED_COLOR::green'
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
               echo "${{ env.version_from_git_tag }}"
+              echo "${{ steps.condabuild.outputs.gitversion }}"
+              echo "The selected color is ${{ steps.condabuild.outputs.SELECTED_COLOR }}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,16 +96,12 @@ jobs:
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               git fetch --prune --unshallow --tags
-              echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
-              echo "Hmmm"
+              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
-              echo '::set-output name=SELECTED_COLOR::green'
-              echo $(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
+              echo $VERSION_FROM_GIT_TAG
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
-              echo "${{ env.version_from_git_tag }}"
               echo "${{ steps.condabuild.outputs.gitversion }}"
-              echo "The selected color is ${{ steps.condabuild.outputs.SELECTED_COLOR }}"
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
 
           - name: Install the Conda Dependencies
             run: | 
+              source /usr/share/miniconda3/etc/profile.d/conda.sh
               conda activate base
               conda config --set always_yes yes --set auto_update_conda false
               conda update conda
@@ -83,6 +84,7 @@ jobs:
 
           - name: Build the Anaconda Package
             run: |
+              source /usr/share/miniconda3/etc/profile.d/conda.sh
               conda activate base
               conda install anaconda-client
               conda config --set anaconda_upload no
@@ -91,6 +93,7 @@ jobs:
 
           - name: Get the output path and upload the package
             run: |
+              source /usr/share/miniconda3/etc/profile.d/conda.sh
               conda activate base
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
-              anaconda upload -u slacgismo  /home/runner/miniconda/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge --numpy 1.16.4
+              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge slacgismo -c --numpy 1.16.4
 
           - name: Get the output path and upload the package
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,8 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+            env:
+              VERSION_FROM_GIT_TAG: `git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test Push
 on: [push]
 jobs:
-    build:
+    test-build:
         runs-on: ubuntu-latest
         environment: deployment
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,13 +93,13 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`"
+              VERSION_FROM_GIT_TAG=$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo "VERSION_FROM_GIT_TAG=$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
               echo $VERSION_FROM_GIT_TAG
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
               echo "${VERSION_FROM_GIT_TAG}"
-              echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_ENV
+              echo "VERSION_FROM_GIT_TAG=$(git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_ENV
               echo $VERSION_FROM_GIT_TAG
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "WHY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,11 +94,13 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              echo "version_from_git_tag=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4" >> $GITHUB_ENV
+              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
+              var=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
+              echo "Hmmm $var"
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
               echo "${{ env.version_from_git_tag }}"
-              print %ENV
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,9 +94,9 @@ jobs:
               conda config --set anaconda_upload no
               anaconda logout
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
+              conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
             run: |
-              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ env.VERSION_FROM_GIT_TAG }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
             with:
               auto-activate-base: true
               activate-environment: ""
-              miniconda-version: "latest"
+              miniconda-version: "4.7.10"
 
           - name: Install the Conda Dependencies
             run: | 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda logout
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
+              yes anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
               echo $VERSION_FROM_GIT_TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,9 @@ jobs:
           - name: Build the Anaconda Package
             run: |
               conda install anaconda-client
+              conda install anaconda-client
               conda config --set anaconda_upload no
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
+              yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge --numpy 1.16.4
 
           - name: Get the output path and upload the package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
               echo "HMMMMM"
               echo "NEXT"
               echo "NEXT"
-              echo "::set-output name=gitversionthree::$(git tag --list "v*[0-9]"" --sort=version:refname | tail -1 | cut -c 2-)"
+              echo "LAST"
               echo "::set-output name=gitversionfour::$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`)"
               echo "${{ steps.condabuild.outputs.gitversion }}"
               echo "${{ steps.condabuild.outputs.gitversiontwo }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
 
     deploy-conda:
-#        needs: build
+        needs: build
         runs-on: ubuntu-latest
 # sets default shell to remove need for source to run the conda shell
         defaults:
@@ -94,9 +94,5 @@ jobs:
               conda config --set anaconda_upload no
               anaconda logout
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
-              conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-
-          - name: Get the output path and upload the package
-            run: |
+              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ env.VERSION_FROM_GIT_TAG }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,5 +91,5 @@ jobs:
 
           - name: Get the output path and upload the package
             env:
-              VERSION_FROM_GIT_TAG: `git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
+              VERSION_FROM_GIT_TAG: git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-
             run: anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,10 +87,9 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-            env:
-              VERSION_FROM_GIT_TAG: `git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
-            run: |
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2
+            env:
+              VERSION_FROM_GIT_TAG: `git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
+            run: anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
 
 # run install twice due to client-size to ensure all files downloaded
 # echo yes before login to prevent anaconda bug breaking automation
+#              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
           - name: Build the Anaconda Package
             id: condabuild
             run: |
@@ -94,7 +95,6 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-#              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
               var=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
               echo "Hmmm $var"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
               conda install anaconda-client
               conda install anaconda-client
               conda config --set anaconda_upload no
-              yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge --numpy 1.16.4
 
           - name: Get the output path and upload the package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
 # run install twice due to client-size to ensure all files downloaded
 # echo yes before login to prevent anaconda bug breaking automation
           - name: Build the Anaconda Package
+            id: condabuild
             run: |
               conda install anaconda-client
               conda install anaconda-client
@@ -98,10 +99,8 @@ jobs:
               echo $VERSION_FROM_GIT_TAG
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
-              echo "${VERSION_FROM_GIT_TAG}"
-              echo "VERSION_FROM_GIT_TAG=$(git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_ENV
-              echo $VERSION_FROM_GIT_TAG
-              echo ${{ env.VERSION_FROM_GIT_TAG }}
-              echo "WHY"
-              echo "${VERSION_FROM_GIT_TAG}"
+              echo "::set-output name=gitversion::$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
+              echo "::set-output name=gitversiontwo::$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
+              echo ${{ steps.condabuild.outputs.gitversion }}
+              echo ${{ steps.condabuild.outputs.gitversiontwo }}
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,11 +96,10 @@ jobs:
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
-              var=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
-              echo "Hmmm $var"
+              echo "Hmmm"
               echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
               echo '::set-output name=SELECTED_COLOR::green'
-              git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-
+              echo $(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
 
           - name: Upload the Anaconda Package
             id: condaload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,5 +94,7 @@ jobs:
               conda config --set anaconda_upload no
               anaconda logout
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo "HMMMMM"
+              echo "${VERSION_FROM_GIT_TAG}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,5 +98,5 @@ jobs:
 
           - name: Get the output path and upload the package
             run: |
-              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2
+              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ env.VERSION_FROM_GIT_TAG }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,16 +95,12 @@ jobs:
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              echo "VERSION_FROM_GIT_TAG=$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
-              echo $VERSION_FROM_GIT_TAG
-              echo ${{ env.VERSION_FROM_GIT_TAG }}
-              echo "HMMMMM"
-              echo "NEXT"
-              echo "NEXT"
-              echo "LAST"
-              echo "::set-output name=gitversionfour::$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`)"
-              echo "${{ steps.condabuild.outputs.gitversion }}"
-              echo "${{ steps.condabuild.outputs.gitversiontwo }}"
-              echo "${{ steps.condabuild.outputs.gitversionthree }}"
-              echo "${{ steps.condabuild.outputs.gitversionfour }}"
+              echo "VERSION_FROM_GIT_TAG=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
+              echo "version_from_git_tag=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`" >> $GITHUB_ENV
+
+          - name: Upload the Anaconda Package
+            id: condaload
+            run: |
+              echo "${{ env.VERSION_FROM_GIT_TAG }}"
+              echo "${{ env.version_from_git_tag }}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
             with:
               auto-activate-base: true
               activate-environment: ""
-              miniconda-version: "4.7.10"
+              miniconda-version: "latest"
 
           - name: Install the Conda Dependencies
             run: | 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
               echo $VERSION_FROM_GIT_TAG
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
-              echo "::set-output name=gitversion::$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
+              echo "NEXT"
               echo "::set-output name=gitversiontwo::$(git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-)"
               echo "::set-output name=gitversionthree::$(git tag --list "v*[0-9]"" --sort=version:refname | tail -1 | cut -c 2-)"
               echo "::set-output name=gitversionfour::$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,11 @@ jobs:
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
               echo "::set-output name=gitversion::$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
-              echo "::set-output name=gitversiontwo::$(`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-`)"
-              echo ${{ steps.condabuild.outputs.gitversion }}
-              echo ${{ steps.condabuild.outputs.gitversiontwo }}
+              echo "::set-output name=gitversiontwo::$(git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-)"
+              echo "::set-output name=gitversionthree::$(git tag --list "v*[0-9]"" --sort=version:refname | tail -1 | cut -c 2-)"
+              echo "::set-output name=gitversionfour::$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`)"
+              echo "${{ steps.condabuild.outputs.gitversion }}"
+              echo "${{ steps.condabuild.outputs.gitversiontwo }}"
+              echo "${{ steps.condabuild.outputs.gitversionthree }}"
+              echo "${{ steps.condabuild.outputs.gitversionfour }}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
 
           - name: Install the Conda Dependencies
             run: | 
-              source /home/runner/miniconda/etc/profile.d/conda.sh
               conda activate base
               conda config --set always_yes yes --set auto_update_conda false
               conda update conda
@@ -84,7 +83,6 @@ jobs:
 
           - name: Build the Anaconda Package
             run: |
-              source /home/runner/miniconda/etc/profile.d/conda.sh
               conda activate base
               conda install anaconda-client
               conda config --set anaconda_upload no
@@ -93,7 +91,6 @@ jobs:
 
           - name: Get the output path and upload the package
             run: |
-              source /home/runner/miniconda/etc/profile.d/conda.sh
               conda activate base
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
               anaconda upload -u slacgismo  /home/runner/miniconda/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
               conda activate base
               conda config --set always_yes yes --set auto_update_conda false
               conda update conda
+              conda info
+              conda config --show-sources
               conda install conda-build
 
           - name: Build the Anaconda Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
     test-build:
         runs-on: ubuntu-latest
-        environment: deployment
+        environment: test
         steps:
           - name: Checkout Repository
             uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda logout
-              yes anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
               echo $VERSION_FROM_GIT_TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,25 +75,20 @@ jobs:
           - name: Install the Conda Dependencies
             run: | 
               source /usr/share/miniconda3/etc/profile.d/conda.sh
-              conda activate base
               conda config --set always_yes yes --set auto_update_conda false
               conda update conda
-              conda info
-              conda config --show-sources
               conda install conda-build
 
           - name: Build the Anaconda Package
             run: |
               source /usr/share/miniconda3/etc/profile.d/conda.sh
-              conda activate base
               conda install anaconda-client
               conda config --set anaconda_upload no
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge --numpy 1.16.4
 
           - name: Get the output path and upload the package
             run: |
               source /usr/share/miniconda3/etc/profile.d/conda.sh
-              conda activate base
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
             run: | 
               wget https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O miniconda.sh
               bash miniconda.sh -b -p "$HOME"/miniconda
+              ln -s libffi.7.dylib libffi.6.dylib
               source /home/runner/miniconda/etc/profile.d/conda.sh
               conda activate base
               conda config --set always_yes yes --set auto_update_conda false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              git fetch --prune --unshallow --tags
               echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
               echo "Hmmm"
               echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
               conda config --set anaconda_upload no
 
           - name: Login to Anaconda
-            run: yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+            run: anaconda login -y --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
 
           - name: Complete the build
             run: VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,15 @@ jobs:
           - name: Checkout Repository
             uses: actions/checkout@v3
 
+          - name: Install Miniconda
+            uses: conda-incubator/setup-miniconda@v2
+            with:
+              auto-activate-base: true
+              activate-environment: ""
+              miniconda-version: "latest"
+
           - name: Install the Conda Dependencies
             run: | 
-              wget https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O miniconda.sh
-              bash miniconda.sh -b -p "$HOME"/miniconda
-              ln -s libffi.7.dylib libffi.6.dylib
               source /home/runner/miniconda/etc/profile.d/conda.sh
               conda activate base
               conda config --set always_yes yes --set auto_update_conda false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,8 +98,9 @@ jobs:
               echo "version_from_git_tag=git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-" >> $GITHUB_ENV
               var=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
               echo "Hmmm $var"
-              echo '::set-output name=gitversion::{git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-}'
+              echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
               echo '::set-output name=SELECTED_COLOR::green'
+              git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-
 
           - name: Upload the Anaconda Package
             id: condaload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,12 +86,9 @@ jobs:
               conda install anaconda-client
               conda install anaconda-client
               conda config --set anaconda_upload no
-
-          - name: Login to Anaconda
-            run: anaconda login -y --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-
-          - name: Complete the build
-            run: VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              anaconda logout
+              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
             env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,14 @@ jobs:
               anaconda logout
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+              echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
+              echo $VERSION_FROM_GIT_TAG
+              echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
+              echo "${VERSION_FROM_GIT_TAG}"
+              echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_ENV
+              echo $VERSION_FROM_GIT_TAG
+              echo ${{ env.VERSION_FROM_GIT_TAG }}
+              echo "WHY"
               echo "${VERSION_FROM_GIT_TAG}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              echo "version_from_git_tag=`git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4" >> $GITHUB_ENV
+              echo "version_from_git_tag=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4" >> $GITHUB_ENV
 
           - name: Upload the Anaconda Package
             id: condaload

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,16 +86,15 @@ jobs:
               conda install conda-build
 
 # run install twice due to client-size to ensure all files downloaded
-# logout before login to prevent anaconda bug breaking automation
+# echo yes before login to prevent anaconda bug breaking automation
           - name: Build the Anaconda Package
             run: |
               conda install anaconda-client
               conda install anaconda-client
               conda config --set anaconda_upload no
-              anaconda logout
               echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
+              echo "VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`"
               echo $VERSION_FROM_GIT_TAG
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test build
+name: Test Push
 on: [push]
 jobs:
     build:
@@ -36,71 +36,3 @@ jobs:
 # Current unit test is not consistent. Occasionally fails despite usually passing. Needs to be fixed.
           - name: Run Unit Tests
             run: sudo coverage run -m unittest
-
-    deploy-pypi:
-        needs: build
-        runs-on: ubuntu-latest
-        environment: deployment
-        steps:
-          - name: Checkout Repository
-            uses: actions/checkout@v3
-
-          - name: Install Python
-            uses: actions/setup-python@v3
-            with:
-              python-version: '3.7'
-
-          - name: Install Twine
-            run: sudo pip install twine
-
-          - name: Create the distribution
-            run: sudo python setup.py sdist bdist_wheel
-
-          - name: Push to PyPI
-            run: sudo twine upload -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
-
-    deploy-conda:
-#        needs: build
-        runs-on: ubuntu-latest
-# sets default shell to remove need for source to run the conda shell
-        defaults:
-          run:
-            shell: bash -l {0}
-        environment: deployment
-        steps:
-          - name: Checkout Repository
-            uses: actions/checkout@v3
-
-# Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
-          - name: Install Miniconda
-            uses: conda-incubator/setup-miniconda@v2
-            with:
-              auto-activate-base: true
-              activate-environment: ""
-              miniconda-version: "latest"
-
-          - name: Install the Conda Dependencies
-            run: | 
-              conda config --set always_yes yes --set auto_update_conda false
-              conda update conda
-              conda install conda-build
-
-# run install twice due to client-size to ensure all files downloaded
-# echo yes before login to prevent anaconda bug breaking automation
-# git tags MUST be fetched otherwise output will be blank
-# bash variables cannot be used in github actions, must use actions specific syntax and methods
-          - name: Build the Anaconda Package
-            id: condabuild
-            run: |
-              conda install anaconda-client
-              conda install anaconda-client
-              conda config --set anaconda_upload no
-              echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              git fetch --prune --unshallow --tags
-              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
-
-          - name: Upload the Anaconda Package
-            id: condaload
-            run: |
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,4 +95,4 @@ jobs:
               anaconda logout
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
-              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ env.VERSION_FROM_GIT_TAG }}-*.tar.bz2
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
               echo ${{ env.VERSION_FROM_GIT_TAG }}
               echo "HMMMMM"
               echo "NEXT"
-              echo "::set-output name=gitversiontwo::$(git tag --list 'v*[0-9]' --sort=version:refname | tail -1 | cut -c 2-)"
+              echo "NEXT"
               echo "::set-output name=gitversionthree::$(git tag --list "v*[0-9]"" --sort=version:refname | tail -1 | cut -c 2-)"
               echo "::set-output name=gitversionfour::$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`)"
               echo "${{ steps.condabuild.outputs.gitversion }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge slacgismo -c --numpy 1.16.4
+              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda logout
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} --no-input
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
               echo $VERSION_FROM_GIT_TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
           - name: Checkout Repository
             uses: actions/checkout@v3
 
+# Necessary action when needing to use AWS credentials.
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v1
             with:
@@ -32,6 +33,7 @@ jobs:
               aws s3 cp s3://slac.gismo.ci.artifacts/mosek.license/mosek.lic $HOME/mosek/mosek.lic
               sudo cp $HOME/mosek/mosek.lic /root/mosek/mosek.lic
 
+# Current unit test is not consistent. Occasionally fails despite usually passing. Needs to be fixed.
           - name: Run Unit Tests
             run: sudo coverage run -m unittest
 
@@ -60,6 +62,7 @@ jobs:
     deploy-conda:
         needs: build
         runs-on: ubuntu-latest
+# sets default shell to remove need for source to run the conda shell
         defaults:
           run:
             shell: bash -l {0}
@@ -68,6 +71,7 @@ jobs:
           - name: Checkout Repository
             uses: actions/checkout@v3
 
+# Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
           - name: Install Miniconda
             uses: conda-incubator/setup-miniconda@v2
             with:
@@ -81,6 +85,8 @@ jobs:
               conda update conda
               conda install conda-build
 
+# run install twice due to client-size to ensure all files downloaded
+# logout before login to prevent anaconda bug breaking automation
           - name: Build the Anaconda Package
             run: |
               conda install anaconda-client
@@ -91,6 +97,6 @@ jobs:
               VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
-            env:
-              VERSION_FROM_GIT_TAG: git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-
-            run: anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2
+            run: |
+              VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)
+              anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-$VERSION_FROM_GIT_TAG-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,8 @@ jobs:
 
 # run install twice due to client-size to ensure all files downloaded
 # echo yes before login to prevent anaconda bug breaking automation
-#              VERSION_FROM_GIT_TAG=$(`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-`) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+# git tags MUST be fetched otherwise output will be blank
+# bash variables cannot be used in github actions, must use actions specific syntax and methods
           - name: Build the Anaconda Package
             id: condabuild
             run: |
@@ -98,10 +99,8 @@ jobs:
               git fetch --prune --unshallow --tags
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo '::set-output name=gitversion::$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)'
-              echo $VERSION_FROM_GIT_TAG
 
           - name: Upload the Anaconda Package
             id: condaload
             run: |
-              echo "${{ steps.condabuild.outputs.gitversion }}"
               anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
               conda install anaconda-client
               conda config --set anaconda_upload no
               anaconda logout
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} --no-input
+              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }} -y
               VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c conda-forge -c slacgismo --numpy 1.16.4
               echo "VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)"
               echo $VERSION_FROM_GIT_TAG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,8 +86,12 @@ jobs:
               conda install anaconda-client
               conda install anaconda-client
               conda config --set anaconda_upload no
-              anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-              VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
+
+          - name: Login to Anaconda
+            run: yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
+
+          - name: Complete the build
+            run: VERSION_FROM_GIT_TAG=`git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-` conda build . -c conda-forge -c slacgismo --numpy 1.16.4
 
           - name: Get the output path and upload the package
             env:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ https://github.com/pypa/sampleproject
 
 # Always prefer setuptools over distutils
 import subprocess
+import os
 from setuptools import setup, find_packages
 from pathlib import Path
 
@@ -18,7 +19,7 @@ from io import open
 here = Path().resolve()
 
 # Get the long description from the README file
-with open((here / "README.md"), encoding="utf-8") as f:
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 # get all the git tags from the cmd line that follow our versioning pattern
@@ -39,7 +40,7 @@ latest_version = latest_git_tag.communicate()[0]
 # PEP 440 won't accept the v in front, so here we remove it, strip the new line and decode the byte stream
 VERSION_FROM_GIT_TAG = latest_version[1:].strip().decode("utf-8")
 
-with open((here / "requirements.txt"), encoding="utf-8") as f:
+with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as f:
     install_requires = f.read().splitlines()
 # removes comments in the requirements file
 dependencies = [dependency for dependency in install_requires if (dependency[0] != "#")]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ https://github.com/pypa/sampleproject
 
 # Always prefer setuptools over distutils
 import subprocess
-import os
 from setuptools import setup, find_packages
 from pathlib import Path
 
@@ -16,10 +15,10 @@ from pathlib import Path
 # Python 3 only projects can skip this import
 from io import open
 
-here = Path().resolve()
+here = Path()
 
 # Get the long description from the README file
-with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+with open((here / "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 # get all the git tags from the cmd line that follow our versioning pattern
@@ -40,7 +39,7 @@ latest_version = latest_git_tag.communicate()[0]
 # PEP 440 won't accept the v in front, so here we remove it, strip the new line and decode the byte stream
 VERSION_FROM_GIT_TAG = latest_version[1:].strip().decode("utf-8")
 
-with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as f:
+with open((here / "requirements.txt"), encoding="utf-8") as f:
     install_requires = f.read().splitlines()
 # removes comments in the requirements file
 dependencies = [dependency for dependency in install_requires if (dependency[0] != "#")]


### PR DESCRIPTION
This update will deprecate use of CircleCI and migrate CI/CD to Github actions.

# Issues

1.  We are deprecating use of CircleCI for cleaner management of CI/CD through Github actions. 

# Fixes

1. All repository CI/CD is managed directly from the repository, along with relevant access and secret management easily granted on a case-by-case basis. This will also reduce additional password management and access needed for CircleCI accounts.
2. Workflows can be easily separated  for clarity and targeted operation, enabling a variety of new development and improvement options. 
3. Different environments can be created with specific environment protection rules, enabling more secure CI/CD operation. 