### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Twine and Build
         run: sudo pip install twine build
@@ -45,7 +45,7 @@ jobs:
       - name: Install the Conda Dependencies
         run: |
           conda install pip
-          pip install cvxpy
+          pip install --upgrade numpy
           conda install conda-build colorama ruamel ruamel.yaml rich jsonschema -c conda-forge
           git fetch --prune --unshallow --tags
           pip install -e .

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-activate-base: true
-          activate-environment: ""
+          activate-environment: "sdt"
           miniconda-version: "latest"
 
       - name: Install the Conda Dependencies

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,16 +40,18 @@ jobs:
       # Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
-          activate-environment: "sdt"
+          auto-activate-base: false
+          activate-environment: sdt
           miniconda-version: "latest"
+          auto-update-conda: true
+          python-version: 3.10
 
       - name: Install the Conda Dependencies
         run: |
           conda config --set always_yes yes --set auto_update_conda false
           conda update conda
           conda install -n base conda-libmamba-solver
-          conda install python=3.11 conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
+          conda install conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
           git fetch --prune --unshallow --tags
           pip install -e .
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build the Anaconda Package
         id: condabuild
         run: |
-          conda install anaconda-client
+          conda install anaconda-client cvxpy -c conda-forge
           conda clean --all
           conda config --set anaconda_upload no --set solver libmamba
           VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)test conda build . -c mosek -c pvlib -c slacgismo -c conda-forge -c stanfordcvxgrp

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,10 +33,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
       # Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
       - uses: conda-incubator/setup-miniconda@v3
         with:
@@ -44,7 +40,7 @@ jobs:
           activate-environment: sdt
           miniconda-version: "latest"
           auto-update-conda: true
-          python-version: 3.10
+          python-version: 3.11
 
       - name: Install the Conda Dependencies
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -49,7 +49,7 @@ jobs:
           conda config --set always_yes yes --set auto_update_conda false
           conda update conda
           conda install -n base conda-libmamba-solver
-          conda install python=3.10 conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
+          conda install python=3.11 conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
           git fetch --prune --unshallow --tags
           pip install -e .
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -36,17 +36,14 @@ jobs:
       # Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: false
-          activate-environment: sdt
           miniconda-version: "latest"
           auto-update-conda: true
           python-version: 3.11
+          channels: conda-forge,anaconda
+          conda-solver: libmamba
 
       - name: Install the Conda Dependencies
         run: |
-          conda config --set always_yes yes --set auto_update_conda false
-          conda update conda
-          conda install -n base conda-libmamba-solver
           conda install conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
           git fetch --prune --unshallow --tags
           pip install -e .
@@ -58,8 +55,8 @@ jobs:
       - name: Build the Anaconda Package
         id: condabuild
         run: |
-          conda install anaconda-client cvxpy -c conda-forge
+          conda install anaconda-client -c conda-forge
           conda clean --all
-          conda config --set anaconda_upload no --set solver libmamba
+          conda config --set anaconda_upload no
           VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)test conda build . -c mosek -c pvlib -c slacgismo -c conda-forge -c stanfordcvxgrp
           echo "gitversion=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Install the Conda Dependencies
         run: |
-          conda install conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
+          conda install pip
+          pip install cvxpy
+          conda install conda-build colorama ruamel ruamel.yaml rich jsonschema -c conda-forge
           git fetch --prune --unshallow --tags
           pip install -e .
 

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -42,10 +42,7 @@ requirements:
 test:
   imports:
     - solardatatools
-  commands:
-    - pip check
-  requires:
-    - pip
+
 
 about:
   home: https://github.com/slacgismo/solar-data-tools

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: echo "Python interpreter: {{ PYTHON }}"
 
 requirements:
   host:

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -42,6 +42,10 @@ requirements:
 test:
   imports:
     - solardatatools
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/slacgismo/solar-data-tools

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} --version
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
   host:
@@ -42,10 +42,6 @@ requirements:
 test:
   imports:
     - solardatatools
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/slacgismo/solar-data-tools

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: echo "Python interpreter: {{ PYTHON }}"
+  script: {{ PYTHON }} --version
 
 requirements:
   host:


### PR DESCRIPTION
IT WAS NUMPY. AND PYTHON.


I couldn't resist the investigation, and nothing seemed to fit. There wasn't a single thing wrong in the convoluted mess that is CVXPY's CI/CD channels. Other than it is a convoluted mess. But it is a working mess. All package info was correct, and I confirmed that the conda maintainer's theory was utterly wrong. 1.4.3 produces the same info as 1.5.1, with the same references.

Therefore, the issue had to be on our side. But where? Why does 1.4.3 work? Then I remembered, when digging through that labyrinth, that there were notes about numpy versions and cvxpy versions scattered in their changelogs. So I created a conda env, installed all the latest supporting packages in our python version 3.10 and tried to import solardatatools. And sure enough, the import failed. It referenced things that did not exist in numpy 2.1.

So I tried the exact same steps in python3.11, and it worked! Because 3.11 supports the latest version of numpy! 

Anyways, I also included a few other handy things. You will likely need to update the deployment workflows as well. Also feel free to fiddle things, but I figure it looks a bit cleaner. Mayhaps pin numpy? 