### PR TITLE
Patch to fix pandas warnings about depricated behavior.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install Twine and Build
         run: sudo pip install twine build
@@ -38,27 +38,24 @@ jobs:
     environment: deployment
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
-      # Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
       - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
-          activate-environment: ""
+          activate-environment: true
+          python-version: 3.12
           miniconda-version: "latest"
+          channels: conda-forge,mosek,slacgismo
+          channel-priority: true
 
       - name: Install the Conda Dependencies
+        shell: bash -l {0}
         run: |
-          conda config --set always_yes yes --set auto_update_conda false
-          conda update conda
-          conda install -n base conda-libmamba-solver
-          conda install python=3.10 conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
-          git fetch --prune --unshallow --tags
           pip install -e .
 
       # echo yes before login to prevent anaconda bug breaking automation
@@ -66,15 +63,16 @@ jobs:
       # bash variables cannot be used in github actions, must use actions specific syntax and methods
       # channels need to be specified on build and are saved in the package for installs
       - name: Build the Anaconda Package
+        shell: bash -l {0}
         id: condabuild
         run: |
-          conda install anaconda-client
-          conda config --set anaconda_upload no --set solver libmamba
-          echo yes | anaconda login --username ${{ secrets.ANACONDA_CLOUD_USERNAME }} --password ${{ secrets.ANACONDA_CLOUD_PASSWORD }}
-          VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . -c mosek -c anaconda -c slacgismo -c conda-forge -c stanfordcvxgrp --numpy 2.0
+          conda install conda-build
+          VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-) conda build . --numpy 2.0 --no-anaconda-upload
           echo "gitversion=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_OUTPUT
 
       - name: Upload the Anaconda Package
+        shell: bash -l {0}
         id: condaload
         run: |
-          anaconda upload -u slacgismo  /usr/share/miniconda3/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2
+          conda install anaconda-client
+          anaconda upload -u slacgismo /home/runner/miniconda3/envs/true/conda-bld/noarch/solar-data-tools-${{ steps.condabuild.outputs.gitversion }}-*.tar.bz2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install Twine and Build
         run: sudo pip install twine build
@@ -28,29 +28,27 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    environment: test-deployment
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
-      # Much better than manual installation, original version Miniconda2-4.7.10-Linux-x86_64.sh is broken
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Install Miniconda
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-activate-base: true
-          activate-environment: ""
+          activate-environment: true
+          python-version: 3.12
           miniconda-version: "latest"
+          channels: conda-forge,mosek,slacgismo
+          channel-priority: true
 
       - name: Install the Conda Dependencies
+        shell: bash -l {0}
         run: |
-          conda config --set always_yes yes --set auto_update_conda false
-          conda update conda
-          conda install -n base conda-libmamba-solver
-          conda install python=3.10 conda-build colorama pip ruamel ruamel.yaml rich jsonschema -c conda-forge
-          git fetch --prune --unshallow --tags
           pip install -e .
 
       # echo yes before login to prevent anaconda bug breaking automation
@@ -58,10 +56,9 @@ jobs:
       # bash variables cannot be used in github actions, must use actions specific syntax and methods
       # channels need to be specified on build and are saved in the package for installs
       - name: Build the Anaconda Package
+        shell: bash -l {0}
         id: condabuild
         run: |
-          conda install anaconda-client
-          conda clean --all
-          conda config --set anaconda_upload no --set solver libmamba
-          VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)test conda build . -c mosek -c slacgismo -c conda-forge -c stanfordcvxgrp --numpy 2.0
+          conda install conda-build
+          VERSION_FROM_GIT_TAG=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)test conda build . --numpy 2.0 --no-anaconda-upload
           echo "gitversion=$(git tag --list "v*[0-9]" --sort=version:refname | tail -1 | cut -c 2-)" >> $GITHUB_OUTPUT

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,12 +8,11 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-  fail_on_warning: true
 
 # Install regular dependencies.
 # Then, install special pinning for RTD.

--- a/solardatatools/time_axis_manipulation.py
+++ b/solardatatools/time_axis_manipulation.py
@@ -77,11 +77,11 @@ def make_time_series(
         df_view = df_view[
             ~df_view.index.duplicated(keep="first")
         ]  # Drop duplicate times
-        df_view.reindex(
+        df_view = df_view.reindex(
             index=time_index, method=None
         )  # Match the master index, interp missing
         #################################################################
-        meas_name = str(df_view[name_key][0])
+        meas_name = str(df_view[name_key].iloc[0])
         col_name = meas_name + "_{:02}".format(counter)
         output[col_name] = df_view[value_key]
         if (


### PR DESCRIPTION
This PR addresses a `FutureWarning` generated by Pandas from line 83 of `time_axis_manipulation.py`:

```
FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] Updated or added relevant tests
- [ ] Updated relevant documentation
- [ ] Added relevant label(s)
- [ ] All comments are resolved
