### PR TITLE
Update dilation.py

### DIFF
--- a/solardatatools/algorithms/dilation.py
+++ b/solardatatools/algorithms/dilation.py
@@ -8,8 +8,13 @@ to undilate it back.
 import numpy as np
 from solardatatools.plotting import plot_2d
 
+DEFAULT = {
+    "nvals_dil": 101,
+    "matrix": "raw",
+}
+
 class Dilation:
-    def __init__(self, data_handler, nvals_dil=101, matrix="raw"):
+    def __init__(self, data_handler, nvals_dil=DEFAULT["nvals_dil"], matrix=DEFAULT["raw"]):
         config = {
             "nvals_dil": nvals_dil,
             "matrix": matrix

--- a/solardatatools/algorithms/dilation.py
+++ b/solardatatools/algorithms/dilation.py
@@ -8,18 +8,13 @@ to undilate it back.
 import numpy as np
 from solardatatools.plotting import plot_2d
 
-DEFAULT = {
-    "nvals_dil": 101,
-    "matrix": "raw",
-}
-
-
 class Dilation:
-    def __init__(self, data_handler, **config):
-        if len(config) == 0:
-            self.config = DEFAULT
-        else:
-            self.config = config
+    def __init__(self, data_handler, nvals_dil=101, matrix="raw"):
+        config = {
+            "nvals_dil": nvals_dil,
+            "matrix": matrix
+        }
+        self.config = config
         if self.config["matrix"] == "raw":
             mat = data_handler.raw_data_matrix
         elif self.config["matrix"] == "filled":

--- a/solardatatools/algorithms/dilation.py
+++ b/solardatatools/algorithms/dilation.py
@@ -14,7 +14,7 @@ DEFAULT = {
 }
 
 class Dilation:
-    def __init__(self, data_handler, nvals_dil=DEFAULT["nvals_dil"], matrix=DEFAULT["raw"]):
+    def __init__(self, data_handler, nvals_dil=DEFAULT["nvals_dil"], matrix=DEFAULT["matrix"]):
         config = {
             "nvals_dil": nvals_dil,
             "matrix": matrix


### PR DESCRIPTION
This PR addresses a bug in the dilation algorithm module. Currently, there are two configuration options: `nvals_dil` and `matrix`. If the user only sets one at runtime, currently the other default value is not loaded, throwing an error. This PR makes the defaults explicit kwargs, which avoids this issue.

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] Updated or added relevant tests
- [ ] Updated relevant documentation
- [ ] Added relevant label(s)
- [ ] All comments are resolved
