### PR TITLE
Quick fix to Dask local csv data plug

### DIFF
--- a/sdt_dask/dataplugs/csv_plug.py
+++ b/sdt_dask/dataplugs/csv_plug.py
@@ -14,9 +14,11 @@ class LocalFiles(DataPlug):
     the source. The main requirement is to keep the ``Dataplug.get_data`` method,
     and make sure the args and returns as defined here.
     """
-    def __init__(self, path_to_files, ext=".csv"):
+
+    def __init__(self, path_to_files, ext=".csv", make_time_series=False):
         self.path = path_to_files
         self.ext = ext
+        self.make_time_series = make_time_series
 
     def _read_file(self, filename):
         """
@@ -49,6 +51,7 @@ class LocalFiles(DataPlug):
             a power column
         """
         self._read_file(key[0])
-        self._clean_data()
+        if self.make_time_series:
+            self._clean_data()
 
         return self.df

--- a/sdt_dask/dataplugs/csv_plug.py
+++ b/sdt_dask/dataplugs/csv_plug.py
@@ -28,7 +28,7 @@ class LocalFiles(DataPlug):
         """
         file = self.path + filename + self.ext
         if self.ext == ".csv":
-            self.df = pd.read_csv(file)
+            self.df = pd.read_csv(file, index_col=0, parse_dates=[0])
         else:
             raise "File type not supported."
 


### PR DESCRIPTION
The default behavior for the local csv file data plug should not try to apply the `make_timeseries` subroutine as a "cleaning" step. This is not a general step, and most users don't need it. There is the option to use it if desired. 

**Checklist for PR authors (skip items if you don't have permissions or they are not applicable)**
- [ ] Updated or added relevant tests
- [ ] Updated relevant documentation
- [ ] Added relevant label(s)
- [ ] All comments are resolved
