### PR TITLE
Prune non-critical source code from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include docs/source/_static/SDT_v1_secondary_blue_text.png
 prune notebooks
+prune docs
+prune tests


### PR DESCRIPTION
This PR fixes deployment issues on PyPI by decreasing the tarball size. Tests and docs are pruned from the source distribution now.