### PR TITLE
pin docutils to fix import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ docs = [
     "sphinx_design",
     "nbsphinx",
     "myst-parser",
-    "nbsphinx_link"
+    "nbsphinx_link",
+    "docutils<0.22"
 ]
 mosek = [
     "mosek"


### PR DESCRIPTION
Attempting to fix read-the-docs build error

See: https://app.readthedocs.org/api/v2/build/32264296.txt
